### PR TITLE
Handle updates of the email collections

### DIFF
--- a/src/crud.rs
+++ b/src/crud.rs
@@ -1,0 +1,3 @@
+pub mod get_email;
+pub mod create_email;
+pub mod delete_email;

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -15,9 +15,9 @@ pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
     match existing_email_id {
         Some(existing_email_id) => {
             println!("existing_email_id: {:?}", existing_email_id);
-            let _: Option<Vec<Record>> = db
+            let _: Option<Record> = db
                 .update((Tables::Emails.to_string(), existing_email_id))
-                .merge(CreateEmailMonthly {
+                .content(CreateEmailMonthly {
                     year_month: get_current_year_month_str(),
                     emails,
                     updated_at: chrono::Local::now().to_rfc3339(),
@@ -44,6 +44,8 @@ pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
     //         updated_at: chrono::Local::now().to_rfc3339(),
     //     })
     //     .await?;
+    //
+    println!("Emails stored");
 
     Ok(())
 }

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -1,0 +1,21 @@
+use crate::{
+    datemath::date::get_current_year_month_str,
+    db::{
+        connect::connect,
+        email::{EmailMonthly, Emails, Record},
+        enums::Tables,
+    },
+};
+
+
+pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
+    let db = connect().await?;
+    let _: Vec<Record> = db
+        .update(Tables::Emails.to_string())
+        .content(EmailMonthly {
+            year_month: get_current_year_month_str(),
+            emails,
+        })
+        .await?;
+    Ok(())
+}

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -2,19 +2,48 @@ use crate::{
     datemath::date::get_current_year_month_str,
     db::{
         connect::connect,
-        email::{CreateEmailMonthly, EmailMonthly, Emails, Record},
+        email::{CreateEmailMonthly, Emails, Record},
         enums::Tables,
     },
 };
 
+use super::get_email::get_email_id_for_current_year_month_by_mailbox;
+
 pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
     let db = connect().await?;
-    let _: Vec<Record> = db
-        .create(Tables::Emails.to_string())
-        .content(CreateEmailMonthly{
-            year_month: get_current_year_month_str(),
-            emails,
-        })
-        .await?;
+    let existing_email_id = get_email_id_for_current_year_month_by_mailbox(&emails.mailbox).await?;
+    match existing_email_id {
+        Some(existing_email_id) => {
+            println!("existing_email_id: {:?}", existing_email_id);
+            let _: Option<Vec<Record>> = db
+                .update((Tables::Emails.to_string(), existing_email_id))
+                .merge(CreateEmailMonthly {
+                    year_month: get_current_year_month_str(),
+                    emails,
+                    updated_at: chrono::Local::now().to_rfc3339(),
+                })
+                .await?;
+        }
+        None => {
+            let _: Vec<Record> = db
+                .create(Tables::Emails.to_string())
+                .content(CreateEmailMonthly {
+                    year_month: get_current_year_month_str(),
+                    emails,
+                    updated_at: chrono::Local::now().to_rfc3339(),
+                })
+                .await?;
+        }
+    }
+
+    // let _: Vec<Record> = db
+    //     .create(Tables::Emails.to_string())
+    //     .content(CreateEmailMonthly {
+    //         year_month: get_current_year_month_str(),
+    //         emails,
+    //         updated_at: chrono::Local::now().to_rfc3339(),
+    //     })
+    //     .await?;
+
     Ok(())
 }

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -2,17 +2,16 @@ use crate::{
     datemath::date::get_current_year_month_str,
     db::{
         connect::connect,
-        email::{EmailMonthly, Emails, Record},
+        email::{CreateEmailMonthly, EmailMonthly, Emails, Record},
         enums::Tables,
     },
 };
 
-
 pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
     let db = connect().await?;
     let _: Vec<Record> = db
-        .update(Tables::Emails.to_string())
-        .content(EmailMonthly {
+        .create(Tables::Emails.to_string())
+        .content(CreateEmailMonthly{
             year_month: get_current_year_month_str(),
             emails,
         })

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -12,6 +12,7 @@ use super::get_email::get_email_id_for_current_year_month_by_mailbox;
 pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
     let db = connect().await?;
     let existing_email_id = get_email_id_for_current_year_month_by_mailbox(&emails.mailbox).await?;
+    let updated_at = chrono::Local::now().to_rfc3339();
     match existing_email_id {
         Some(existing_email_id) => {
             println!("existing_email_id: {:?}", existing_email_id);
@@ -20,7 +21,7 @@ pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
                 .content(CreateEmailMonthly {
                     year_month: get_current_year_month_str(),
                     emails,
-                    updated_at: chrono::Local::now().to_rfc3339(),
+                    updated_at,
                 })
                 .await?;
         }
@@ -30,22 +31,10 @@ pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
                 .content(CreateEmailMonthly {
                     year_month: get_current_year_month_str(),
                     emails,
-                    updated_at: chrono::Local::now().to_rfc3339(),
+                    updated_at,
                 })
                 .await?;
         }
     }
-
-    // let _: Vec<Record> = db
-    //     .create(Tables::Emails.to_string())
-    //     .content(CreateEmailMonthly {
-    //         year_month: get_current_year_month_str(),
-    //         emails,
-    //         updated_at: chrono::Local::now().to_rfc3339(),
-    //     })
-    //     .await?;
-    //
-    println!("Emails stored");
-
     Ok(())
 }

--- a/src/crud/delete_email.rs
+++ b/src/crud/delete_email.rs
@@ -1,0 +1,60 @@
+use std::i32;
+
+use serde::{Deserialize, Serialize};
+use surrealdb::sql::{Id, Thing};
+
+use crate::{
+    datemath::date::get_current_year_month_str,
+    db::{connect::connect, email::Record, enums::Tables},
+};
+
+use super::get_email::get_emails_current_year_month;
+
+use crate::email_parser::parser::EmailDetails;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EmailMonthly {
+    id: Thing,
+    year_month: String,
+    emails: Emails,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Emails {
+    mailbox: String,
+    details: Vec<EmailDetails>,
+}
+
+pub async fn remove_emails() -> surrealdb::Result<()> {
+    let db = connect().await?;
+    let year_month = get_current_year_month_str();
+    let sql = "
+    SELECT id FROM type::table($table) WHERE year_month = $year_month;
+";
+    let mut result = db
+        .query(sql)
+        .bind(("table", Tables::Emails.to_string()))
+        .bind(("year_month", year_month))
+        .await?;
+    // let emails: Vec<EmailMonthly> = result.take(0)?;
+    let raw_ids: Vec<Record> = result.take(0)?;
+    let ids: Vec<String> = raw_ids.iter().map(|x| x.id.id.to_string()).collect();
+
+    // delete all ids
+    //
+    ids.iter().for_each(|id| {
+        let email: Option<EmailMonthly> =
+            db.delete((Tables::Emails.to_string(), ids.clone()));
+    });
+
+    // let email: Option<EmailMonthly> = db
+    //     .delete((Tables::Emails.to_string(), ids.clone()))
+    //     .await?;
+
+    // let ids: Option<Record> = result.take(0)?;
+    // println!("ids: {:?}", ids);
+    // println!("emails: {:?}", emails);
+    dbg!(&ids);
+    // dbg!(&emails);
+    Ok(())
+}

--- a/src/crud/delete_email.rs
+++ b/src/crud/delete_email.rs
@@ -1,60 +1,14 @@
-use std::i32;
-
-use serde::{Deserialize, Serialize};
-use surrealdb::sql::{Id, Thing};
-
 use crate::{
-    datemath::date::get_current_year_month_str,
-    db::{connect::connect, email::Record, enums::Tables},
+    crud::get_email::get_emails_id_for_current_year_month,
+    db::{connect::connect, email::EmailMonthly, enums::Tables},
 };
-
-use super::get_email::get_emails_current_year_month;
-
-use crate::email_parser::parser::EmailDetails;
-
-#[derive(Debug, Serialize, Deserialize)]
-struct EmailMonthly {
-    id: Thing,
-    year_month: String,
-    emails: Emails,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct Emails {
-    mailbox: String,
-    details: Vec<EmailDetails>,
-}
 
 pub async fn remove_emails() -> surrealdb::Result<()> {
     let db = connect().await?;
-    let year_month = get_current_year_month_str();
-    let sql = "
-    SELECT id FROM type::table($table) WHERE year_month = $year_month;
-";
-    let mut result = db
-        .query(sql)
-        .bind(("table", Tables::Emails.to_string()))
-        .bind(("year_month", year_month))
-        .await?;
-    // let emails: Vec<EmailMonthly> = result.take(0)?;
-    let raw_ids: Vec<Record> = result.take(0)?;
-    let ids: Vec<String> = raw_ids.iter().map(|x| x.id.id.to_string()).collect();
-
-    // delete all ids
-    //
-    ids.iter().for_each(|id| {
-        let email: Option<EmailMonthly> =
-            db.delete((Tables::Emails.to_string(), ids.clone()));
-    });
-
-    // let email: Option<EmailMonthly> = db
-    //     .delete((Tables::Emails.to_string(), ids.clone()))
-    //     .await?;
-
-    // let ids: Option<Record> = result.take(0)?;
-    // println!("ids: {:?}", ids);
-    // println!("emails: {:?}", emails);
-    dbg!(&ids);
-    // dbg!(&emails);
+    let ids_to_remove = get_emails_id_for_current_year_month().await?;
+    for id in &ids_to_remove {
+        let _deleted_email: Option<EmailMonthly> =
+            db.delete((Tables::Emails.to_string(), id.clone())).await?;
+    }
     Ok(())
 }

--- a/src/crud/delete_email.rs
+++ b/src/crud/delete_email.rs
@@ -1,11 +1,11 @@
 use crate::{
-    crud::get_email::get_emails_id_for_current_year_month,
+    crud::get_email::get_emails_ids_for_current_year_month,
     db::{connect::connect, email::EmailMonthly, enums::Tables},
 };
 
 pub async fn remove_emails() -> surrealdb::Result<()> {
     let db = connect().await?;
-    let ids_to_remove = get_emails_id_for_current_year_month().await?;
+    let ids_to_remove = get_emails_ids_for_current_year_month().await?;
     for id in &ids_to_remove {
         let _deleted_email: Option<EmailMonthly> =
             db.delete((Tables::Emails.to_string(), id.clone())).await?;

--- a/src/crud/get_email.rs
+++ b/src/crud/get_email.rs
@@ -49,7 +49,7 @@ pub async fn get_emails_current_year_month_mailbox(
     Ok(())
 }
 
-pub async fn get_emails_id_for_current_year_month() -> surrealdb::Result<Vec<String>> {
+pub async fn get_emails_ids_for_current_year_month() -> surrealdb::Result<Vec<String>> {
     let db = connect().await?;
     let year_month = get_current_year_month_str();
     let sql = "SELECT id FROM type::table($table) WHERE year_month = $year_month;";
@@ -62,4 +62,22 @@ pub async fn get_emails_id_for_current_year_month() -> surrealdb::Result<Vec<Str
     let ids: Vec<String> = raw_ids.iter().map(|x| x.id.id.to_string()).collect();
     dbg!(&ids);
     Ok(ids)
+}
+
+pub async fn get_email_id_for_current_year_month_by_mailbox(
+    mailbox: &str,
+) -> surrealdb::Result<Option<String>> {
+    let db = connect().await?;
+    let year_month = get_current_year_month_str();
+    let sql = "SELECT id FROM type::table($table) WHERE year_month = $year_month AND emails.mailbox = $mailbox;";
+    let mut result = db
+        .query(sql)
+        .bind(("table", Tables::Emails.to_string()))
+        .bind(("year_month", year_month))
+        .bind(("mailbox", mailbox))
+        .await?;
+    let raw_ids: Vec<Record> = result.take(0)?;
+    // NOTE: There should be exactly one id per mailbox per month
+    let email_id: Option<String> = raw_ids.iter().map(|x| x.id.id.to_string()).next();
+    Ok(email_id)
 }

--- a/src/crud/get_email.rs
+++ b/src/crud/get_email.rs
@@ -1,6 +1,6 @@
 use crate::datemath::date::get_current_year_month_str;
 use crate::db::connect::connect;
-use crate::db::email::EmailMonthly;
+use crate::db::email::{EmailMonthly, Record};
 use crate::db::enums::Tables;
 
 pub async fn get_emails() -> surrealdb::Result<Vec<EmailMonthly>> {
@@ -47,4 +47,19 @@ pub async fn get_emails_current_year_month_mailbox(
     let emails: Vec<EmailMonthly> = result.take(0)?;
     dbg!(&emails);
     Ok(())
+}
+
+pub async fn get_emails_id_for_current_year_month() -> surrealdb::Result<Vec<String>> {
+    let db = connect().await?;
+    let year_month = get_current_year_month_str();
+    let sql = "SELECT id FROM type::table($table) WHERE year_month = $year_month;";
+    let mut result = db
+        .query(sql)
+        .bind(("table", Tables::Emails.to_string()))
+        .bind(("year_month", year_month))
+        .await?;
+    let raw_ids: Vec<Record> = result.take(0)?;
+    let ids: Vec<String> = raw_ids.iter().map(|x| x.id.id.to_string()).collect();
+    dbg!(&ids);
+    Ok(ids)
 }

--- a/src/crud/get_email.rs
+++ b/src/crud/get_email.rs
@@ -1,0 +1,50 @@
+use crate::datemath::date::get_current_year_month_str;
+use crate::db::connect::connect;
+use crate::db::email::EmailMonthly;
+use crate::db::enums::Tables;
+
+pub async fn get_emails() -> surrealdb::Result<Vec<EmailMonthly>> {
+    let db = connect().await?;
+    let emails: Vec<EmailMonthly> = db.select(Tables::Emails.to_string()).await?;
+    dbg!(&emails);
+    Ok(emails)
+}
+
+pub async fn get_emails_current_year_month() -> surrealdb::Result<()> {
+    let db = connect().await?;
+    let year_month = get_current_year_month_str();
+    let sql = "
+    SELECT * FROM type::table($table) WHERE year_month = $year_month;
+";
+    let mut result = db
+        .query(sql)
+        .bind(("table", Tables::Emails.to_string()))
+        .bind(("year_month", year_month))
+        .await?;
+    let emails: Vec<EmailMonthly> = result.take(0)?;
+    dbg!(&emails);
+    Ok(())
+}
+
+pub async fn get_emails_current_year_month_mailbox(
+    mailbox: &str,
+    year_month: &str,
+) -> surrealdb::Result<()> {
+    let db = connect().await?;
+    let year_month_str = match year_month {
+        "" => get_current_year_month_str(),
+        _ => year_month.to_string(),
+    };
+    let sql = "
+    SELECT * FROM type::table($table) WHERE year_month = $year_month AND emails.mailbox = $mailbox;
+    ";
+    let mut result = db
+        .query(sql)
+        .bind(("table", Tables::Emails.to_string()))
+        .bind(("year_month", year_month_str))
+        .bind(("mailbox", mailbox))
+        .await?;
+    let emails: Vec<EmailMonthly> = result.take(0)?;
+    dbg!(&emails);
+    Ok(())
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,5 @@
 pub mod connect;
 pub mod email;
 pub mod enums;
+#[cfg(test)]
+mod tests;

--- a/src/db/connect.rs
+++ b/src/db/connect.rs
@@ -48,3 +48,4 @@ pub async fn connect() -> Result<Surreal<surrealdb::engine::remote::ws::Client>,
         .await?;
     Ok(db)
 }
+

--- a/src/db/email.rs
+++ b/src/db/email.rs
@@ -11,6 +11,13 @@ pub struct Record {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EmailMonthly {
+    pub id: Thing,
+    pub year_month: String,
+    pub emails: Emails,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateEmailMonthly {
     pub year_month: String,
     pub emails: Emails,
 }

--- a/src/db/email.rs
+++ b/src/db/email.rs
@@ -14,12 +14,14 @@ pub struct EmailMonthly {
     pub id: Thing,
     pub year_month: String,
     pub emails: Emails,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateEmailMonthly {
     pub year_month: String,
     pub emails: Emails,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/db/email.rs
+++ b/src/db/email.rs
@@ -1,84 +1,22 @@
 use serde::{Deserialize, Serialize};
 use surrealdb::sql::Thing;
 
-use crate::datemath::date::get_current_year_month_str;
-use crate::db::connect::connect;
 use crate::email_parser::parser::EmailDetails;
 
-use super::enums::Tables;
 
 #[derive(Debug, Deserialize)]
-struct Record {
-    #[allow(dead_code)]
-    id: Thing,
+pub struct Record {
+    pub id: Thing,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EmailMonthly {
-    year_month: String,
-    emails: Emails,
+    pub year_month: String,
+    pub emails: Emails,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Emails {
     pub mailbox: String,
     pub details: Vec<EmailDetails>,
-}
-
-pub async fn store_emails(emails: Emails) -> surrealdb::Result<()> {
-    let db = connect().await?;
-    let _: Vec<Record> = db
-        .create(Tables::Emails.to_string())
-        .content(EmailMonthly {
-            year_month: get_current_year_month_str(),
-            emails,
-        })
-        .await?;
-    Ok(())
-}
-
-pub async fn get_emails() -> surrealdb::Result<Vec<EmailMonthly>> {
-    let db = connect().await?;
-    let emails: Vec<EmailMonthly> = db.select(Tables::Emails.to_string()).await?;
-    dbg!(&emails);
-    Ok(emails)
-}
-
-pub async fn get_emails_current_year_month() -> surrealdb::Result<()> {
-    let db = connect().await?;
-    let year_month = get_current_year_month_str();
-    let sql = "
-    SELECT * FROM type::table($table) WHERE year_month = $year_month;
-";
-    let mut result = db
-        .query(sql)
-        .bind(("table", Tables::Emails.to_string()))
-        .bind(("year_month", year_month))
-        .await?;
-    let emails: Vec<EmailMonthly> = result.take(0)?;
-    dbg!(&emails);
-    Ok(())
-}
-
-pub async fn get_emails_current_year_month_mailbox(
-    mailbox: &str,
-    year_month: &str,
-) -> surrealdb::Result<()> {
-    let db = connect().await?;
-    let year_month_str = match year_month {
-        "" => get_current_year_month_str(),
-        _ => year_month.to_string(),
-    };
-    let sql = "
-    SELECT * FROM type::table($table) WHERE year_month = $year_month AND emails.mailbox = $mailbox;
-    ";
-    let mut result = db
-        .query(sql)
-        .bind(("table", Tables::Emails.to_string()))
-        .bind(("year_month", year_month_str))
-        .bind(("mailbox", mailbox))
-        .await?;
-    let emails: Vec<EmailMonthly> = result.take(0)?;
-    dbg!(&emails);
-    Ok(())
 }

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -1,0 +1,15 @@
+use crate::db::connect::connect;
+
+#[tokio::test]
+async fn test_connect() {
+    // Set up environment variables for testing
+    std::env::set_var("DB_HOST", "127.0.0.1");
+    std::env::set_var("DB_PORT", "8000");
+    std::env::set_var("DB_USERNAME", "root");
+    std::env::set_var("DB_PASSWORD", "root");
+    std::env::set_var("DB_NAME", "antowrker");
+    std::env::set_var("DB_NAMESPACE", "emails");
+
+    let result = connect().await;
+    assert!(result.is_ok(), "Connection failed: {:?}", result.err());
+}

--- a/src/email_parser/attachment.rs
+++ b/src/email_parser/attachment.rs
@@ -73,12 +73,15 @@ fn handle_pure_pdf(
         .params
         .get("name")
         .cloned()
-        .unwrap_or_else(|| format!("attachment_{}_unnamed.pdf", uid));
+        .unwrap_or_else(|| format!("attachment_{}_unnamed.pdf", uid))
+        .replace(" ", "_")
+        .replace("/", "_");
     let full_path_save_location = Path::new(save_location).join(&filename);
     let binary_content = part
         .get_body_raw()
         .map_err(|e| eprintln!("Failed to get body raw: {}", e))
         .expect("Failed to get body raw");
+    println!("Saving attachment: {:?}", full_path_save_location);
     let mut file = File::create(full_path_save_location.clone())
         .map_err(|e| eprintln!("Failed to create file: {}", e))
         .expect("Failed to create file");

--- a/src/email_parser/inbox.rs
+++ b/src/email_parser/inbox.rs
@@ -5,9 +5,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use native_tls::TlsStream;
 
 use crate::{
-    db::email::{store_emails, Emails},
-    factories::credentials::EmailAccountBuilder,
-    rules::define::define_rules,
+    crud::create_email::store_emails, db::email:: Emails, factories::credentials::EmailAccountBuilder, rules::define::define_rules
 };
 
 use super::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use command::open::open_save_location_invoices;
-use db::email::{get_emails, get_emails_current_year_month, get_emails_current_year_month_mailbox};
+use crud::{delete_email::remove_emails, get_email::{
+    get_emails, get_emails_current_year_month, get_emails_current_year_month_mailbox,
+}};
 use dotenv::dotenv;
 use email_parser::main::process_emails;
 use email_sender::sender::send_emails;
@@ -12,6 +14,7 @@ extern crate imap;
 extern crate native_tls;
 
 pub mod command;
+pub mod crud;
 pub mod datemath;
 pub mod db;
 pub mod email_parser;
@@ -109,6 +112,8 @@ enum Commands {
         year_month: Option<String>,
         #[arg(short, long, action, help = "Return all stored emails history")]
         all: bool,
+        #[arg(help = "Remove emials")]
+        remove: String,
     },
 }
 
@@ -153,16 +158,23 @@ async fn main() {
             all,
             mailbox,
             year_month,
+            remove,
         } => {
+            if remove == "remove" {
+                remove_emails().await.unwrap();
+                return;
+            }
             if all {
                 get_emails().await.unwrap();
                 return;
             }
             match (mailbox, year_month) {
-                (Some(mb), Some(ym)) => get_emails_current_year_month_mailbox(&mb, &ym)
-                    .await
-                    .unwrap(),
-                (Some(mb), None) => get_emails_current_year_month_mailbox(&mb, "")
+                (Some(mailbox), Some(year_month)) => {
+                    get_emails_current_year_month_mailbox(&mailbox, &year_month)
+                        .await
+                        .unwrap()
+                }
+                (Some(mailbox), None) => get_emails_current_year_month_mailbox(&mailbox, "")
                     .await
                     .unwrap(),
                 _ => get_emails_current_year_month().await.unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ enum Commands {
         #[arg(short, long, action, help = "Return all stored emails history")]
         all: bool,
         #[arg(help = "Remove emials")]
-        remove: String,
+        remove: Option<String>,
     },
 }
 
@@ -160,9 +160,14 @@ async fn main() {
             year_month,
             remove,
         } => {
-            if remove == "remove" {
-                remove_emails().await.unwrap();
-                return;
+            match remove {
+                Some(remove) => {
+                    if remove == "remove" {
+                        remove_emails().await.unwrap();
+                        return;
+                    }
+                }
+                None => {}
             }
             if all {
                 get_emails().await.unwrap();


### PR DESCRIPTION
I want to be able to run `antowrker emails` several time during the month and all new emails belonging to a given observed mailbox will result in the single existing entry being updated. Currently, I am creating a new document every time there is a new email for all inboxes. 

The ultimate goal is to have a single document per observed mailbox per a current `yaer_month`.