### PR TITLE
Improve logic about storing mailbox info and latest uid

### DIFF
--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -25,9 +25,8 @@ impl CreateEmailDbOps for DatabaseConnection {
         let existing_email_id = &self
             .get_email_id_for_current_year_month_by_mailbox(&emails.mailbox)
             .await?;
-        let existing_mailbox_id = &self
-            .get_mailbox_id_by_mailbox(&emails.mailbox)
-            .await?;
+        let existing_mailbox_id = &self.get_mailbox_id_by_mailbox(&emails.mailbox).await?;
+
         let updated_at = chrono::Local::now().to_rfc3339();
         match existing_email_id {
             Some(existing_email_id) => {
@@ -54,7 +53,7 @@ impl CreateEmailDbOps for DatabaseConnection {
                 let _: Vec<Record> = db
                     .create(Tables::Mailbox.to_string())
                     .content(CreateMailboxMonthly {
-                        year_month: get_current_year_month_str(),
+                        mailbox: emails.mailbox,
                         updated_at: updated_at.clone(),
                         latest_uid: max_uid,
                     })
@@ -84,7 +83,7 @@ impl CreateEmailDbOps for DatabaseConnection {
                 let _: Vec<Record> = db
                     .create(Tables::Mailbox.to_string())
                     .content(CreateMailboxMonthly {
-                        year_month: get_current_year_month_str(),
+                        mailbox: emails.mailbox,
                         updated_at: updated_at.clone(),
                         latest_uid: max_uid,
                     })

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -12,6 +12,8 @@ use crate::{
 use crate::crud::get_email::GetEmailDbOps;
 use crate::db::connect::DatabaseConnection;
 
+use super::get_mailbox::GetMailboxDbOps;
+
 #[allow(async_fn_in_trait)]
 pub trait CreateEmailDbOps {
     async fn store_emails(&self, emails: Emails) -> surrealdb::Result<()>;
@@ -22,6 +24,9 @@ impl CreateEmailDbOps for DatabaseConnection {
         let db = connect().await?;
         let existing_email_id = &self
             .get_email_id_for_current_year_month_by_mailbox(&emails.mailbox)
+            .await?;
+        let existing_mailbox_id = &self
+            .get_mailbox_id_by_mailbox(&emails.mailbox)
             .await?;
         let updated_at = chrono::Local::now().to_rfc3339();
         match existing_email_id {

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -17,15 +17,63 @@ use super::get_mailbox::GetMailboxDbOps;
 #[allow(async_fn_in_trait)]
 pub trait CreateEmailDbOps {
     async fn store_emails(&self, emails: Emails) -> surrealdb::Result<()>;
+    async fn store_mailbox_info(
+        &self,
+        emails: &Emails,
+        updated_at: String,
+    ) -> surrealdb::Result<()>;
 }
 
 impl CreateEmailDbOps for DatabaseConnection {
+    async fn store_mailbox_info(
+        &self,
+        emails: &Emails,
+        updated_at: String,
+    ) -> surrealdb::Result<()> {
+        let db = connect().await?;
+        let existing_mailbox_id = &self.get_mailbox_id_by_mailbox(&emails.mailbox).await?;
+        let max_uid = emails
+            .clone()
+            .details
+            .iter()
+            .max_by_key(|x| x.uid)
+            .unwrap_or(&EmailDetails {
+                uid: 0,
+                subject: "".to_string(),
+                from: vec!["".to_string()],
+                date: chrono::Utc::now(),
+            })
+            .uid;
+        match existing_mailbox_id {
+            Some(existing_mailbox_id) => {
+                let _: Option<Record> = db
+                    .update((Tables::Mailbox.to_string(), existing_mailbox_id))
+                    .content(CreateMailboxMonthly {
+                        mailbox: emails.mailbox.clone(),
+                        updated_at: updated_at.clone(),
+                        latest_uid: max_uid,
+                    })
+                    .await?;
+            }
+            None => {
+                let _: Vec<Record> = db
+                    .create(Tables::Mailbox.to_string())
+                    .content(CreateMailboxMonthly {
+                        mailbox: emails.mailbox.clone(),
+                        updated_at: updated_at.clone(),
+                        latest_uid: max_uid,
+                    })
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
     async fn store_emails(&self, emails: Emails) -> surrealdb::Result<()> {
         let db = connect().await?;
         let existing_email_id = &self
             .get_email_id_for_current_year_month_by_mailbox(&emails.mailbox)
             .await?;
-        let existing_mailbox_id = &self.get_mailbox_id_by_mailbox(&emails.mailbox).await?;
 
         let updated_at = chrono::Local::now().to_rfc3339();
         match existing_email_id {

--- a/src/crud/create_email.rs
+++ b/src/crud/create_email.rs
@@ -86,26 +86,7 @@ impl CreateEmailDbOps for DatabaseConnection {
                         updated_at: updated_at.clone(),
                     })
                     .await?;
-                let max_uid = emails
-                    .clone()
-                    .details
-                    .iter()
-                    .max_by_key(|x| x.uid)
-                    .unwrap_or(&EmailDetails {
-                        uid: 0,
-                        subject: "".to_string(),
-                        from: vec!["".to_string()],
-                        date: chrono::Utc::now(),
-                    })
-                    .uid;
-                let _: Vec<Record> = db
-                    .create(Tables::Mailbox.to_string())
-                    .content(CreateMailboxMonthly {
-                        mailbox: emails.mailbox,
-                        updated_at: updated_at.clone(),
-                        latest_uid: max_uid,
-                    })
-                    .await?;
+                self.store_mailbox_info(&emails, updated_at).await?;
             }
             None => {
                 let _: Vec<Record> = db
@@ -116,26 +97,7 @@ impl CreateEmailDbOps for DatabaseConnection {
                         updated_at: updated_at.clone(),
                     })
                     .await?;
-                let max_uid = emails
-                    .clone()
-                    .details
-                    .iter()
-                    .max_by_key(|x| x.uid)
-                    .unwrap_or(&EmailDetails {
-                        uid: 0,
-                        subject: "".to_string(),
-                        from: vec!["".to_string()],
-                        date: chrono::Utc::now(),
-                    })
-                    .uid;
-                let _: Vec<Record> = db
-                    .create(Tables::Mailbox.to_string())
-                    .content(CreateMailboxMonthly {
-                        mailbox: emails.mailbox,
-                        updated_at: updated_at.clone(),
-                        latest_uid: max_uid,
-                    })
-                    .await?;
+                self.store_mailbox_info(&emails, updated_at).await?;
             }
         }
         Ok(())

--- a/src/crud/delete_mailbox.rs
+++ b/src/crud/delete_mailbox.rs
@@ -12,7 +12,7 @@ pub trait DeleteMailboxDbOps {
 impl DeleteMailboxDbOps for DatabaseConnection {
     async fn remove_mailbox(&self) -> surrealdb::Result<()> {
         let db = connect().await?;
-        let ids_to_remove = &self.get_mailbox_ids_for_current_year_month().await?;
+        let ids_to_remove = &self.get_mailbox_ids().await?;
         for id in ids_to_remove {
             let _deleted_mailbox: Option<MailboxMonthly> =
                 db.delete((Tables::Mailbox.to_string(), id.clone())).await?;

--- a/src/crud/get_mailbox.rs
+++ b/src/crud/get_mailbox.rs
@@ -1,17 +1,14 @@
-use crate::{
-    datemath::date::get_current_year_month_str,
-    db::{
-        connect::{connect, DatabaseConnection},
-        email::Record,
-        enums::Tables,
-        mailbox::MailboxMonthly,
-    },
+use crate::db::{
+    connect::{connect, DatabaseConnection},
+    email::Record,
+    enums::Tables,
+    mailbox::MailboxMonthly,
 };
 
 #[allow(async_fn_in_trait)]
 pub trait GetMailboxDbOps {
     async fn get_mailboxes(&self) -> surrealdb::Result<Vec<MailboxMonthly>>;
-    async fn get_mailbox_ids_for_current_year_month(&self) -> surrealdb::Result<Vec<String>>;
+    async fn get_mailbox_ids(&self) -> surrealdb::Result<Vec<String>>;
     async fn get_mailbox_id_by_mailbox(&self, mailbox: &str) -> surrealdb::Result<Option<String>>;
 }
 
@@ -23,14 +20,12 @@ impl GetMailboxDbOps for DatabaseConnection {
         Ok(mailboxes)
     }
 
-    async fn get_mailbox_ids_for_current_year_month(&self) -> surrealdb::Result<Vec<String>> {
+    async fn get_mailbox_ids(&self) -> surrealdb::Result<Vec<String>> {
         let db = connect().await?;
-        let year_month = get_current_year_month_str();
-        let sql = "SELECT id FROM type::table($table) WHERE year_month = $year_month;";
+        let sql = "SELECT id FROM type::table($table);";
         let mut result = db
             .query(sql)
             .bind(("table", Tables::Mailbox.to_string()))
-            .bind(("year_month", year_month))
             .await?;
         let raw_ids: Vec<Record> = result.take(0)?;
         let ids: Vec<String> = raw_ids.iter().map(|x| x.id.id.to_string()).collect();
@@ -46,8 +41,14 @@ impl GetMailboxDbOps for DatabaseConnection {
             .bind(("table", Tables::Mailbox.to_string()))
             .bind(("mailbox", mailbox))
             .await?;
+        // NOTE This should be a single record
         let raw_ids: Vec<Record> = result.take(0)?;
-        let id = raw_ids.iter().map(|x| x.id.id.to_string()).collect::<Vec<String>>().pop();
+        let id = raw_ids
+            .iter()
+            .map(|x| x.id.id.to_string())
+            .collect::<Vec<String>>()
+            .pop();
+        println!("MAILBOX_ID");
         dbg!(&id);
         Ok(id)
     }

--- a/src/crud/get_mailbox.rs
+++ b/src/crud/get_mailbox.rs
@@ -48,8 +48,6 @@ impl GetMailboxDbOps for DatabaseConnection {
             .map(|x| x.id.id.to_string())
             .collect::<Vec<String>>()
             .pop();
-        println!("MAILBOX_ID");
-        dbg!(&id);
         Ok(id)
     }
 }

--- a/src/db/mailbox.rs
+++ b/src/db/mailbox.rs
@@ -3,7 +3,7 @@ use surrealdb::sql::Thing;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateMailboxMonthly {
-    pub year_month: String,
+    pub mailbox: String,
     pub updated_at: String,
     pub latest_uid: u32,
 }
@@ -11,7 +11,7 @@ pub struct CreateMailboxMonthly {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MailboxMonthly {
     pub id: Thing,
-    pub year_month: String,
+    pub mailbox: String,
     pub updated_at: String,
     pub latest_uid: u32,
 }


### PR DESCRIPTION
Improving logic about storing mailbox info and latest uid.

- When a mailbox entry does not exists in db, create a new one.
- Number of mailbox entires in a db is equal to number of email accounts.
- When a mailbox entry exists in a db, update it.
- Check currently calculated max_uid and compare with the one stored in db. Use max of them as a new max_uid that is used to update a mailbox entry in a db. Do this for every mailbox.

Closes https://github.com/mgierada/antworker/issues/4